### PR TITLE
add more font faces

### DIFF
--- a/hoon-ts-mode.el
+++ b/hoon-ts-mode.el
@@ -5,6 +5,7 @@
 (require 'treesit)
 
 (defvar hoon--treesit-font-lock-setting
+
   (treesit-font-lock-rules
    :feature 'comment
    :language 'hoon
@@ -16,7 +17,7 @@
 
    :feature 'aura
    :language 'hoon
-   '((aura) @font-lock-type-face)
+   '((aura) @font-lock-builtin-face)
 
    :feature 'shadow
    :language 'hoon
@@ -24,20 +25,37 @@
 
    :feature 'rune
    :language 'hoon
-   '((rune) @font-lock-constant-face)
+   '((rune) @font-lock-variable-name-face)
+
+   :feature 'typeCast
+   :language 'hoon
+   '((typeCast (_)) @font-lock-type-face)
+
+   :feature 'zapzap
+   :language 'hoon
+   '((zapzap (_)) @font-lock-warning-face)
+
+   :feature 'name
+   :language 'hoon
+   '((name) @font-lock-variable-name-face)
 
    :feature 'lusNames
    :language 'hoon
    '((luslusTall (name) @font-lock-function-name-face)
      (lusbucTall (name) @font-lock-function-name-face))
 
+   :feature 'gateCall
+   :language 'hoon
+   '((gateCall) @font-lock-constant-call-face)
+
    :feature 'constants
    :language 'hoon
-   '((mold) @font-lock-constant-face
-     (lark) @font-lock-constant-face
-     (date) @font-lock-constant-face
-     (term) @font-lock-constant-face
-     (number) @font-lock-constant-face))
+   '((mold) @font-lock-keyword-face
+     (lark) @font-lock-doc-markup-face
+     (date) @font-lock-keyword-face
+     (number) @font-lock-keyword-face
+     (boolean) @font-lock-keyword-face
+     (term) @font-lock-keyword-face))
 
   "Tree-sitter font-lock settings.")
 


### PR DESCRIPTION
I've added some new font faces and reassigned some other ones. Feel free to improve on this. Obviously this is all subjective and should improve as we add more features.

![image](https://github.com/urbit-pilled/hoon-ts-mode/assets/1708810/b61c0b22-8236-4032-9f1c-e079d5d7d402)

I'm not sure why, but the `zapzap` query does not work.
